### PR TITLE
Docs improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Laravel Binput
 ==============
 
-Laravel Binput was created by, and is maintained by [Graham Campbell](https://github.com/GrahamCampbell), and is an input protector for [Laravel 5](http://laravel.com). It utilises my [Laravel Security](https://github.com/GrahamCampbell/Laravel-Security) package. Feel free to check out the [change log](CHANGELOG.md), [releases](https://github.com/GrahamCampbell/Laravel-Binput/releases), [license](LICENSE), and [contribution guidelines](CONTRIBUTING.md).
+Laravel Binput was created by, and is maintained by [Graham Campbell](https://github.com/GrahamCampbell), and is an input protector for [Laravel 5](http://laravel.com) that prevents potentially dangerous elements like `<script>` tags in any input you receive, from doing harm. It utilises my [Laravel Security](https://github.com/GrahamCampbell/Laravel-Security) package. 
+
+Feel free to check out the [change log](CHANGELOG.md), [releases](https://github.com/GrahamCampbell/Laravel-Binput/releases), [license](LICENSE), and [contribution guidelines](CONTRIBUTING.md).
 
 ![Laravel Binput](https://cloud.githubusercontent.com/assets/2829600/4432294/c1133286-468c-11e4-801e-6f589ad9cd37.PNG)
 
@@ -60,6 +62,13 @@ Laravel Binput requires no configuration. Just follow the simple install instruc
 This is the class of most interest. It is bound to the ioc container as `'binput'` and can be accessed using the `Facades\Binput` facade. There are a few public methods of interest.
 
 The `'all'`, `'get'`, `'input'`, `'only'`, `'except'`, and `'old'` methods have an identical api to the methods found on the laravel request class accept from they all accept two extra parameters at the end. The first extra parameter is a boolean representing if the input should be trimmed. The second extra parameter is a boolean representing if the input should be xss cleaned. Both extra parameters are default to true.
+
+```php
+// request input data: 'test' => '123', 'foo' => '<script>alert(\'bar\');</script>    '
+
+$input = Binput::all(); // 'test' => '123', 'foo' => '[removed]alert&#40;\'bar\'&#41;;[removed]'
+
+```
 
 There are two additional methods added to the public api. The first is a method called `'map'` which will remap the output from the `'only'` method. The `'map'` function requires an associative array as the first parameter. The second method is the `'clean'` function. It takes three parameters. The first is the value to be cleaned (it can be an array, and will be recursively iterated over and cleaned), and the final two are trim and clean, which behave in the same way as earlier.
 


### PR DESCRIPTION
I think this could make it easier to understand. I would also add an example to clarify what the `xss` boolean does, as well as showing the default values from the config.

If you are fine with this I can create an additional PR with those changes.

I think that users who are not comfortable with tests, etc. will not look into those, and you do not want to digg through tests just to figure out what a package does.

Worst scenario, people just don't use the package, which would be sad, as it is a really good one.

This would fix #28
